### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Hibbu-Creative-Project/hibbucms/security/code-scanning/1](https://github.com/Hibbu-Creative-Project/hibbucms/security/code-scanning/1)

To resolve this issue, you should specify a minimal `permissions:` block in your workflow. Since this workflow seems to only run tests (install, build, test, etc.) and does not appear to require any write access to repository content or pull requests, you should set minimal permissions, such as `contents: read`, either at the workflow root (recommended, applies to all jobs) or specifically for the `ci` job. Editing the workflow root is simplest and applies safest defaults.

To implement this, insert the following block immediately after the `name: tests` line (line 1):

```yaml
permissions:
  contents: read
```

This restricts the default permissions for this workflow's jobs, minimizing the risk posed by the GITHUB_TOKEN.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
